### PR TITLE
Add progress bar, remove batch/debug options

### DIFF
--- a/root_optimize/__init__.py
+++ b/root_optimize/__init__.py
@@ -7,11 +7,12 @@ __version__ = '0.4.6'
 __all__ = ['json_encoder',
            'utils']
 
-import os, sys
-# grab the stdout and have python write to this instead
-# ROOT will write to the original stdout
-STDOUT = os.fdopen(os.dup(sys.stdout.fileno()), 'w')
+# Set up ROOT
+import ROOT
+ROOT.PyConfig.IgnoreCommandLineOptions = True
+ROOT.gROOT.SetBatch(True)
 
 import logging
+from .utils import TqdmLoggingHandler
 logger = logging.getLogger("root_optimize")
-logger.addHandler(logging.StreamHandler(STDOUT))
+logger.addHandler(TqdmLoggingHandler())

--- a/root_optimize/__init__.py
+++ b/root_optimize/__init__.py
@@ -3,7 +3,7 @@
 from __future__ import absolute_import
 from __future__ import print_function
 
-__version__ = '0.4.6'
+__version__ = '0.5.0'
 __all__ = ['json_encoder',
            'utils']
 

--- a/root_optimize/command_line.py
+++ b/root_optimize/command_line.py
@@ -69,7 +69,7 @@ def do_cuts(args):
   from numpy import memmap, uint64
   pids = memmap(os.path.join(tempfile.mkdtemp(), 'pids'), dtype=uint64, shape=num_cores, mode='w+')
 
-  overall_progress = tqdm.tqdm(total=len(dids), desc='Num. files', position=0, leave=True, unit='file')
+  overall_progress = tqdm.tqdm(total=len(dids), desc='Num. files', position=0, leave=True, unit='file', dynamic_ncols=True)
   class CallBack(object):
     completed = defaultdict(int)
 
@@ -344,6 +344,7 @@ def main():
   cuts_parser.add_argument('--weightsFile', type=str, required=False, dest='weightsFile', metavar='<weights file>', help='json file containing weights by DID', default='weights.json')
   cuts_parser.add_argument('-o', '--output', required=False, type=str, dest='output_directory', metavar='<directory>', help='output directory to store the <hash>.json files', default='cuts')
   cuts_parser.add_argument('--numpy', required=False, action='store_true', help='Enable numpy optimization to speed up the cuts processing')
+  cuts_parser.add_argument('--hide-subtasks', action='store_true', help='Enable to hide the subtask progress on cuts. This might be if you get annoyed by how buggy it is.')
 
 
   # needs: signal, bkgd, bkgdUncertainty, insignificanceThreshold, tree, eventWeight

--- a/root_optimize/command_line.py
+++ b/root_optimize/command_line.py
@@ -66,8 +66,11 @@ def do_cuts(args):
   num_cores = min(multiprocessing.cpu_count(), args.num_cores)
   logger.log(25, "Using {0} cores".format(num_cores) )
 
-  from numpy import memmap, uint64
-  pids = memmap(os.path.join(tempfile.mkdtemp(), 'pids'), dtype=uint64, shape=num_cores, mode='w+')
+  pids = None
+  # if pids is None, do_cut() will disable the progress
+  if not args.hide_subtasks:
+    from numpy import memmap, uint64
+    pids = memmap(os.path.join(tempfile.mkdtemp(), 'pids'), dtype=uint64, shape=num_cores, mode='w+')
 
   overall_progress = tqdm.tqdm(total=len(dids), desc='Num. files', position=0, leave=True, unit='file', dynamic_ncols=True)
   class CallBack(object):

--- a/root_optimize/command_line.py
+++ b/root_optimize/command_line.py
@@ -63,7 +63,7 @@ def do_cuts(args):
   # parallelize
   num_cores = min(multiprocessing.cpu_count(), args.num_cores)
   logger.log(25, "Using {0} cores".format(num_cores) )
-  results = Parallel(n_jobs=num_cores)(delayed(utils.do_cut)(did, files, supercuts, weights, args.tree_name, args.output_directory, args.eventWeightBranch, args.numpy) for did, files in dids.iteritems())
+  results = Parallel(n_jobs=num_cores)(delayed(utils.do_cut)(did, files, supercuts, weights, args.tree_name, args.output_directory, args.eventWeightBranch, args.numpy, i) for i, (did, files) in enumerate(dids.iteritems()))
 
   for did, result in zip(dids, results):
     logger.log(25, 'DID {0:s}: {1:s}'.format(did, 'ok' if result[0] else 'not ok'))

--- a/root_optimize/command_line.py
+++ b/root_optimize/command_line.py
@@ -69,7 +69,7 @@ def do_cuts(args):
   from numpy import memmap, uint64
   pids = memmap(os.path.join(tempfile.mkdtemp(), 'pids'), dtype=uint64, shape=num_cores, mode='w+')
 
-  overall_progress = tqdm.tqdm(total=len(dids), desc='Num. files', position=num_cores, leave=True, unit='files')
+  overall_progress = tqdm.tqdm(total=len(dids), desc='Num. files', position=0, leave=True, unit='file')
   class CallBack(object):
     completed = defaultdict(int)
 
@@ -80,6 +80,7 @@ def do_cuts(args):
     def __call__(self, index):
       CallBack.completed[self.parallel] += 1
       overall_progress.update()
+      overall_progress.refresh()
       if self.parallel._original_iterable:
         self.parallel.dispatch_next()
 

--- a/root_optimize/utils.py
+++ b/root_optimize/utils.py
@@ -385,7 +385,7 @@ def do_cut(did, files, supercuts, weights, tree_name, output_directory, eventWei
 
     # iterate over the cuts available
     cuts = {}
-    for cut in tqdm.tqdm(get_cut(copy.deepcopy(supercuts)), desc='Working on DID {0:s}'.format(did), total=get_n_cuts(supercuts), position=position, leave=True, mininterval=10, maxinterval=60, unit='cuts'):
+    for cut in tqdm.tqdm(get_cut(copy.deepcopy(supercuts)), desc='Working on DID {0:s}'.format(did), total=get_n_cuts(supercuts), position=position+1, leave=True, mininterval=5, maxinterval=10, unit='cuts'):
       cut_hash = get_cut_hash(cut)
       rawEvents, weightedEvents = apply_cuts(tree, cut, eventWeightBranch, doNumpy, canvas=canvas)
       scaledEvents = weightedEvents*sample_scaleFactor

--- a/root_optimize/utils.py
+++ b/root_optimize/utils.py
@@ -330,10 +330,12 @@ def apply_cuts(tree, cuts, eventWeightBranch, doNumpy=False, canvas=None):
 #@echo(write=logger.debug)
 def do_cut(did, files, supercuts, weights, tree_name, output_directory, eventWeightBranch, doNumpy, pids):
 
-  # handle pid registration
-  if os.getpid() not in pids: pids[np.argmax(pids==0)] = os.getpid()
-  # this gives us the position of this particular process in our list of processes
-  position = np.where(pids==os.getpid())[0][0]
+  position = -1
+  if pids is not None:
+    # handle pid registration
+    if os.getpid() not in pids: pids[np.argmax(pids==0)] = os.getpid()
+    # this gives us the position of this particular process in our list of processes
+    position = np.where(pids==os.getpid())[0][0]
 
   start = clock()
   try:
@@ -385,7 +387,7 @@ def do_cut(did, files, supercuts, weights, tree_name, output_directory, eventWei
 
     # iterate over the cuts available
     cuts = {}
-    for cut in tqdm.tqdm(get_cut(copy.deepcopy(supercuts)), desc='Working on DID {0:s}'.format(did), total=get_n_cuts(supercuts), position=position+1, leave=True, mininterval=5, maxinterval=10, unit='cuts', dynamic_ncols=True):
+    for cut in tqdm.tqdm(get_cut(copy.deepcopy(supercuts)), desc='Working on DID {0:s}'.format(did), total=get_n_cuts(supercuts), disable=(position==-1), position=position+1, leave=True, mininterval=5, maxinterval=10, unit='cuts', dynamic_ncols=True):
       cut_hash = get_cut_hash(cut)
       rawEvents, weightedEvents = apply_cuts(tree, cut, eventWeightBranch, doNumpy, canvas=canvas)
       scaledEvents = weightedEvents*sample_scaleFactor

--- a/root_optimize/utils.py
+++ b/root_optimize/utils.py
@@ -385,7 +385,7 @@ def do_cut(did, files, supercuts, weights, tree_name, output_directory, eventWei
 
     # iterate over the cuts available
     cuts = {}
-    for cut in tqdm.tqdm(get_cut(copy.deepcopy(supercuts)), desc='Working on DID {0:s}'.format(did), total=get_n_cuts(supercuts), position=position+1, leave=True, mininterval=5, maxinterval=10, unit='cuts'):
+    for cut in tqdm.tqdm(get_cut(copy.deepcopy(supercuts)), desc='Working on DID {0:s}'.format(did), total=get_n_cuts(supercuts), position=position+1, leave=True, mininterval=5, maxinterval=10, unit='cuts', dynamic_ncols=True):
       cut_hash = get_cut_hash(cut)
       rawEvents, weightedEvents = apply_cuts(tree, cut, eventWeightBranch, doNumpy, canvas=canvas)
       scaledEvents = weightedEvents*sample_scaleFactor

--- a/root_optimize/utils.py
+++ b/root_optimize/utils.py
@@ -282,7 +282,13 @@ def apply_cuts(tree, cuts, eventWeightBranch, doNumpy=False, canvas=None):
     return apply_selection(tree, cuts, eventWeightBranch, canvas)
 
 #@echo(write=logger.debug)
-def do_cut(did, files, supercuts, weights, tree_name, output_directory, eventWeightBranch, doNumpy, i):
+def do_cut(did, files, supercuts, weights, tree_name, output_directory, eventWeightBranch, doNumpy, pids):
+
+  # handle pid registration
+  if os.getpid() not in pids: pids[np.argmax(pids==0)] = os.getpid()
+  # this gives us the position of this particular process in our list of processes
+  position = np.where(pids==os.getpid())[0][0]
+
   start = clock()
   try:
     # load up the tree for the files
@@ -333,7 +339,7 @@ def do_cut(did, files, supercuts, weights, tree_name, output_directory, eventWei
 
     # iterate over the cuts available
     cuts = {}
-    for cut in tqdm.tqdm(get_cut(copy.deepcopy(supercuts)), total=get_n_cuts(supercuts), position=i):
+    for cut in tqdm.tqdm(get_cut(copy.deepcopy(supercuts)), desc='Working on DID {0:s}'.format(did), total=get_n_cuts(supercuts), position=position, leave=True, mininterval=10, maxinterval=60, unit='cuts'):
       cut_hash = get_cut_hash(cut)
       rawEvents, weightedEvents = apply_cuts(tree, cut, eventWeightBranch, doNumpy, canvas=canvas)
       scaledEvents = weightedEvents*sample_scaleFactor

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,8 @@ setup(
       'joblib~=0.8',
       'numexpr~=2.6',
       'root-numpy~=4.7',
-      'rootpy~=0.9'
+      'rootpy~=0.9',
+      'tqdm~=4.11'
     ],
     entry_points = {
       'console_scripts': ['rooptimize=root_optimize.command_line:main']


### PR DESCRIPTION
Closes #79 ! Huzzzzzzah.
  
<img width="1457" alt="screenshot 2017-03-28 21 24 17" src="https://cloud.githubusercontent.com/assets/761483/24436774/0822dc76-1403-11e7-8675-5ad41f02c69b.png">

- adds progress bars using tqdm
  - top-level for `do_cuts` showing the number of files left to process
  - sub-level for `do_cut` showing the number of cuts left for a currently-processing file, this can be disabled with `--hide-subtasks` if the output is super buggy for you (`tqdm` is not thread-safe)
- removes batch/debug modes and moves the code to `__init__.py` for consistent application
- bump to 0.5.0 as this changes the command line options for sure (for `cuts`)