### PR TITLE
Key "list" for supercuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -580,6 +580,7 @@ Key | Type | Description
 ----|------|------------
 selections | string | the various selections to apply for the cut
 st3 | list | a list of [start, stop, step] values for each set of pivots
+list | list | a list of [cut1, cut2, ..., cutN] values for each set of pivots
 
 **Note**: the direction in which cuts are generated can be controlled by running cuts in increasing values (`start < stop`, `step > 0`) or decreasing values (`start > stop`, `step < 0`).
 

--- a/src/root_optimize/utils.py
+++ b/src/root_optimize/utils.py
@@ -298,9 +298,18 @@ def get_cut(superCuts, index=0):
                 for cut in get_cut(superCuts, index + 1):
                     yield cut
         except KeyError:
-            item["fixed"] = True
-            for cut in get_cut(superCuts, index + 1):
-                yield cut
+            try: # look for "list" key 
+                for pivot in itertools.product(*item["list"]): # chiara: change here
+                    # set the pivot value
+                    item["pivot"] = pivot
+                    item["fixed"] = False
+                    # recursively call, yield the result which is the superCuts
+                    for cut in get_cut(superCuts, index + 1):
+                        yield cut
+            except KeyError: # if "st3" and "list" keys are not there, it's a fixed cut
+                item["fixed"] = True
+                for cut in get_cut(superCuts, index + 1):
+                    yield cut
 
 
 def get_n_cuts(supercuts):
@@ -311,6 +320,8 @@ def get_n_cuts(supercuts):
                 lambda x, y: x * y,
                 (np.ceil((st3[1] - st3[0]) / st3[2]) for st3 in supercut["st3"]),
             )
+        if "list" in supercut: # if it's a list of values, just look at len()
+            total *= reduce((lambda x, y: x * y), [len(l) for l in supercut["list"]])             
     return total
 
 


### PR DESCRIPTION
Add an additional key (`list`) in addition to `st3` for supercuts files. 
With this key, the selections can be specified in a list of values and not only as [start, stop, step] (useful e.g. to have non-equally-spaced selections)